### PR TITLE
Fix minute desync between board and log

### DIFF
--- a/matches/static/matches/js/live_match.js
+++ b/matches/static/matches/js/live_match.js
@@ -38,6 +38,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const eventsBox = eventsListContainer ? eventsListContainer.querySelector('.events-box') : null; // Внутренний блок для добавления
     const statBox = document.querySelector('.stat-box'); // Блок для статистики
     const injuryActionForm = document.querySelector('#matchUserAction-inj'); // Форма для травмы
+    const continueBtn = document.getElementById('continueMinute');
 
     // Проверяем наличие основных элементов для обновления
     if (!timeElement) { console.error('Element #matchTime not found!'); }
@@ -45,6 +46,36 @@ document.addEventListener('DOMContentLoaded', function() {
     if (!awayScoreElement) { console.error('Element .away-score not found!'); }
     if (!eventsBox) { console.error('Element .events-box inside #originalEvents not found!'); }
     if (!statBox) { console.error('Element .stat-box not found!'); }
+
+    function handleStatusChange(status) {
+        if (continueBtn) {
+            if (status === 'paused') {
+                continueBtn.style.display = 'block';
+                continueBtn.disabled = false;
+            } else {
+                continueBtn.style.display = 'none';
+            }
+        }
+    }
+
+    handleStatusChange(initialStatus);
+
+    function sendNextMinute() {
+        if (matchSocket && matchSocket.readyState === WebSocket.OPEN) {
+            matchSocket.send(JSON.stringify({
+                type: 'control',
+                action: 'next_minute',
+                match_id: matchId
+            }));
+        }
+    }
+
+    if (continueBtn) {
+        continueBtn.addEventListener('click', function() {
+            sendNextMinute();
+            continueBtn.disabled = true;
+        });
+    }
     // injuryActionForm может отсутствовать, это не критично
 
      // --- Функция для отображения сообщений пользователю ---
@@ -291,6 +322,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 if (data.status && data.status !== currentMatchStatus) {
                      console.log(`Match status changed from ${currentMatchStatus} to: ${data.status}`);
                      currentMatchStatus = data.status; // Обновляем текущий статус
+                     handleStatusChange(data.status);
                      const statusDisplay = document.getElementById('matchStatusDisplay');
                      if(statusDisplay) statusDisplay.textContent = data.status; // Обновляем отображение статуса
 

--- a/matches/tasks.py
+++ b/matches/tasks.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from channels.layers import get_channel_layer
 from asgiref.sync import async_to_sync
 from django.db import transaction # Импортируем transaction
+from django.conf import settings
 
 # Убедитесь, что импорты Player и Club есть
 from players.models import Player 
@@ -19,6 +20,57 @@ from .models import Match, MatchEvent
 
 logger = logging.getLogger(__name__)
 
+# Duration of one simulated minute in seconds. Set MATCH_TICK_SECONDS in
+# Django settings to override. Use 60 for real time or shorter for testing.
+TICK_SECONDS = getattr(settings, "MATCH_TICK_SECONDS", 5)
+
+
+# --- Interactive minute simulation task ---
+@shared_task(name="matches.simulate_next_minute")
+def simulate_next_minute(match_id: int):
+    """Simulate a single minute and pause the match until the next command."""
+    start = time.monotonic()
+    try:
+        with transaction.atomic():
+            match = Match.objects.select_for_update().get(id=match_id)
+
+            if match.status != "in_progress":
+                logger.info(
+                    f"Match {match_id} not in progress (status {match.status})."
+                )
+                return f"Match {match_id} not in progress"
+
+            from .match_simulation import simulate_one_minute
+
+            updated = simulate_one_minute(match)
+            if not updated:
+                logger.error(f"simulate_one_minute failed for match {match_id}")
+                return f"Simulation failed {match_id}"
+
+            minute = updated.current_minute
+            updated.save()
+
+        broadcast_minute_events_in_chunks.delay(match_id, minute, duration=10)
+
+        elapsed = time.monotonic() - start
+        remain = TICK_SECONDS - elapsed
+        if remain > 0:
+            time.sleep(remain)
+
+        with transaction.atomic():
+            match = Match.objects.select_for_update().get(id=match_id)
+            if match.current_minute >= 90:
+                match.status = "finished"
+            elif match.status == "in_progress":
+                match.status = "paused"
+            match.save()
+
+        return f"Minute {minute} done for match {match_id}"
+
+    except Match.DoesNotExist:
+        logger.error(f"Match {match_id} does not exist in simulate_next_minute")
+    except Exception as e:
+        logger.exception(f"Error in simulate_next_minute {match_id}: {e}")
 
 # --- ЗАДАЧА СИМУЛЯЦИИ МИНУТЫ ---
 # ПРЕДУПРЕЖДЕНИЕ: Эта задача здесь для примера. Если реальный вызов 

--- a/matches/templates/matches/match_detail.html
+++ b/matches/templates/matches/match_detail.html
@@ -66,6 +66,7 @@
                                         0'
                                     {% endif %}
                                 </div>
+                                <button id="continueMinute" class="btn btn-sm btn-primary mt-2" style="display:none;" type="button">Continue</button>
                             </div>
 
                             <div class="col-5"> {# Используем col-5 для симметрии #}


### PR DESCRIPTION
## Summary
- revert broadcast payload patch
- add interactive minute-by-minute simulation via new Celery task and websocket control
- surface a Continue button and JS helper to trigger the next minute
- trigger the new task when creating matches or manually advancing minutes

## Testing
- `python -m py_compile matches/tasks.py matches/match_simulation.py matches/views.py`