### PR TITLE
Remove broadcast call from view

### DIFF
--- a/matches/match_simulation.py
+++ b/matches/match_simulation.py
@@ -460,19 +460,10 @@ def simulate_one_minute(match: Match) -> Match | None:
 
         logger.debug(f"--- Minute {minute} simulation ended for Match {match.id} ---")
 
-        # --- ИЗМЕНЕНО: Вызов задачи Celery РАСКОММЕНТИРОВАН ---
-        try:
-            # Импорт внутри функции, чтобы избежать проблем с циклическим импортом при запуске
-            from .tasks import broadcast_minute_events_in_chunks 
-            broadcast_minute_events_in_chunks.delay(match.id, minute, duration=10) 
-            logger.debug(f"Scheduled broadcast task for match {match.id}, minute {minute}")
-        except ImportError:
-             logger.error("Could not import broadcast_minute_events_in_chunks from .tasks. Event broadcasting skipped.")
-        except Exception as celery_e:
-             logger.exception(f"Error scheduling broadcast task for match {match.id}: {celery_e}")
-        # -------------------------------------------------------
+        # Broadcasting is scheduled by the Celery task controlling the simulation
+        # so no manual scheduling occurs here.
 
-        return match 
+        return match
 
     # Обработка ЛЮБОЙ ошибки внутри основной симуляции минуты
     except Exception as e:

--- a/matches/views.py
+++ b/matches/views.py
@@ -13,7 +13,7 @@ from .models import Match, MatchEvent
 from clubs.models import Club
 from players.models import Player
 # Импорт Celery-задач
-from .tasks import simulate_match_minute, broadcast_minute_events_in_chunks, simulate_next_minute
+from .tasks import simulate_match_minute, simulate_next_minute
 from .utils import extract_player_id
 from tournaments.models import Championship, League
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger


### PR DESCRIPTION
## Summary
- ensure Celery task handles event broadcasting
- drop unused broadcast import from views
- remove broadcast scheduling from match_simulation

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*