### PR TITLE
Update broadcast task defaults

### DIFF
--- a/matches/match_simulation.py
+++ b/matches/match_simulation.py
@@ -463,8 +463,8 @@ def simulate_one_minute(match: Match) -> Match | None:
         # --- ИЗМЕНЕНО: Вызов задачи Celery РАСКОММЕНТИРОВАН ---
         try:
             # Импорт внутри функции, чтобы избежать проблем с циклическим импортом при запуске
-            from .tasks import broadcast_minute_events_in_chunks 
-            broadcast_minute_events_in_chunks.delay(match.id, minute, duration=10) 
+            from .tasks import broadcast_minute_events_in_chunks
+            broadcast_minute_events_in_chunks.delay(match.id, minute)
             logger.debug(f"Scheduled broadcast task for match {match.id}, minute {minute}")
         except ImportError:
              logger.error("Could not import broadcast_minute_events_in_chunks from .tasks. Event broadcasting skipped.")

--- a/matches/tasks.py
+++ b/matches/tasks.py
@@ -51,7 +51,7 @@ def simulate_next_minute(match_id: int):
             minute = updated.current_minute
             updated.save()
 
-        broadcast_minute_events_in_chunks.delay(match_id, minute, duration=10)
+        broadcast_minute_events_in_chunks.delay(match_id, minute)
 
         elapsed = time.monotonic() - start
         remain = TICK_SECONDS - elapsed
@@ -127,7 +127,7 @@ def simulate_match_minute(match_id: int):
 
 # --- ИЗМЕНЕННАЯ ЗАДАЧА broadcast_minute_events_in_chunks ---
 @shared_task(name='matches.broadcast_minute_events_in_chunks')
-def broadcast_minute_events_in_chunks(match_id: int, minute: int, duration: int = 10):
+def broadcast_minute_events_in_chunks(match_id: int, minute: int, duration: int = 4):
     """
     Поштучно (с паузой) отправляет по WebSocket ТОЛЬКО СОБЫТИЯ, 
     созданные в указанную минуту матча.
@@ -140,9 +140,11 @@ def broadcast_minute_events_in_chunks(match_id: int, minute: int, duration: int 
              logger.error(f"Match {match_id} does not exist for broadcasting events.")
              return f"Match {match_id} not found"
         
-        # Если матч завершен и это не финальные минуты, прекращаем трансляцию
-        if match.status in ['finished', 'error', 'cancelled'] and minute < 89:
-            logger.info(f"Match {match_id} already {match.status}. Skipping broadcast for minute {minute}.")
+        # Если матч завершён с ошибкой или отменён, прекращаем трансляцию
+        if match.status in ['error', 'cancelled']:
+            logger.info(
+                f"Match {match_id} already {match.status}. Skipping broadcast for minute {minute}."
+            )
             return f"Match {match_id} {match.status}, no broadcast needed for minute {minute}"
 
         # Получаем все события минуты, включая связанные объекты для имен


### PR DESCRIPTION
## Summary
- change `broadcast_minute_events_in_chunks` default duration to `4`
- skip broadcasting only if match status is `error` or `cancelled`
- update callers to use new default

## Testing
- `python -m py_compile matches/tasks.py matches/match_simulation.py`