### PR TITLE
Expose tick duration and add next minute control

### DIFF
--- a/matches/templates/matches/match_detail.html
+++ b/matches/templates/matches/match_detail.html
@@ -10,7 +10,8 @@
             <div class="card mb-4 shadow-sm" {# Добавлены тени для красоты #}
                  id="matchInfoArea"
                  data-match-id="{{ match.id }}"
-                 data-match-status="{{ match.status }}">
+                 data-match-status="{{ match.status }}"
+                 data-tick-seconds="{{ tick_seconds }}">
                 <div class="card-header bg-light"> {# Светлый фон заголовка #}
                     <div class="d-flex justify-content-between align-items-center flex-wrap"> {# flex-wrap для мобильных #}
                         <h2 class="h4 mb-0 me-3"> {# Уменьшен заголовок #}
@@ -67,6 +68,7 @@
                                     {% endif %}
                                 </div>
                                 <button id="continueMinute" class="btn btn-sm btn-primary mt-2" style="display:none;" type="button">Continue</button>
+                                <button id="nextMinuteBtn" class="btn btn-sm btn-success mt-2" style="display:none;" type="button">Next Minute</button>
                             </div>
 
                             <div class="col-5"> {# Используем col-5 для симметрии #}

--- a/matches/views.py
+++ b/matches/views.py
@@ -13,7 +13,12 @@ from .models import Match, MatchEvent
 from clubs.models import Club
 from players.models import Player
 # Импорт Celery-задач
-from .tasks import simulate_match_minute, broadcast_minute_events_in_chunks, simulate_next_minute
+from .tasks import (
+    simulate_match_minute,
+    broadcast_minute_events_in_chunks,
+    simulate_next_minute,
+    TICK_SECONDS,
+)
 from .utils import extract_player_id
 from tournaments.models import Championship, League
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
@@ -172,6 +177,7 @@ def match_detail(request, pk):
         'home_prev_lineup_list': home_prev_lineup_list,
         'away_prev_match': away_prev_match,
         'away_prev_lineup_list': away_prev_lineup_list,
+        'tick_seconds': TICK_SECONDS,
     }
 
     logger.info(f'[match_detail] Контекст подготовлен. Рендер страницы match_detail.html для матча ID={pk}')


### PR DESCRIPTION
## Summary
- show the next minute button on the match page and include tick duration data
- provide tick duration from view context
- update live match script to handle new button and timed auto-continue

## Testing
- `python manage.py test -v 2` *(fails: ModuleNotFoundError: No module named 'django')*