### PR TITLE
Fix minute desync between board and log

### DIFF
--- a/matches/static/matches/js/live_match.js
+++ b/matches/static/matches/js/live_match.js
@@ -239,8 +239,6 @@ document.addEventListener('DOMContentLoaded', function() {
 
                      // Обновляем состояние после загрузки всех исторических событий
                      if (timeElement && data.minute !== undefined) timeElement.textContent = `${data.minute}'`;
-                     if (homeScoreElement && data.home_score !== undefined) homeScoreElement.textContent = data.home_score;
-                     if (awayScoreElement && data.away_score !== undefined) awayScoreElement.textContent = data.away_score;
                      updateStatistics(data);
 
                 }
@@ -248,12 +246,15 @@ document.addEventListener('DOMContentLoaded', function() {
                 else if (data.partial_update === true && data.events && Array.isArray(data.events) && data.events.length > 0) {
                     console.log('Processing single EVENT update (from broadcast_minute_events_in_chunks):', data.events[0]);
                     // Добавляем событие в список (функция addEventToList добавляет в начало)
-                    addEventToList(data.events[0]);
+                    const eventObj = data.events[0];
+                    addEventToList(eventObj);
                     // Также обновляем состояние, если оно пришло в этом же сообщении (обычно нет)
                     if (data.minute !== undefined) timeElement.textContent = `${data.minute}'`;
-                    if (data.home_score !== undefined) homeScoreElement.textContent = data.home_score;
-                    if (data.away_score !== undefined) awayScoreElement.textContent = data.away_score;
-                    updateStatistics(data);
+                    // Обновляем счет только при показе события "goal"
+                    if (eventObj.event_type === "goal") {
+                        if (data.home_score !== undefined) homeScoreElement.textContent = data.home_score;
+                        if (data.away_score !== undefined) awayScoreElement.textContent = data.away_score;
+                    }
 
                 }
                  // --- Обработка только обновления состояния (от send_update) ---
@@ -266,20 +267,11 @@ document.addEventListener('DOMContentLoaded', function() {
                     } else if(timeElement) {
                          console.warn("State update received, but 'minute' is missing or undefined.");
                     }
-
-                    // Обновляем счет
-                    if (homeScoreElement && data.home_score !== undefined) {
-                        homeScoreElement.textContent = data.home_score;
-                    } else if(homeScoreElement) {
-                         console.warn("State update received, but 'home_score' is missing or undefined.");
-                    }
-                     if (awayScoreElement && data.away_score !== undefined) {
-                        awayScoreElement.textContent = data.away_score;
-                    } else if(awayScoreElement) {
-                         console.warn("State update received, but 'away_score' is missing or undefined.");
-                    }
+                    // Счет не обновляем здесь, он изменится вместе с событием
 
                     // Обновляем статистику
+
+
                     updateStatistics(data);
                 } else {
                      // Неизвестный формат сообщения

--- a/matches/tasks.py
+++ b/matches/tasks.py
@@ -117,7 +117,10 @@ def broadcast_minute_events_in_chunks(match_id: int, minute: int, duration: int 
         for i, event in enumerate(events):
             # Формируем данные ТОЛЬКО для этого события
             event_player_name = f"{event.player.first_name} {event.player.last_name}" if event.player else ""
-            related_player_name = f"{event.related_player.first_name} {event.related_player.last_name}" if event.related_player else ""
+            related_player_name = (
+                f"{event.related_player.first_name} {event.related_player.last_name}"
+                if event.related_player else ""
+            )
             
             single_event_data = {
                 "minute": event.minute,
@@ -130,12 +133,21 @@ def broadcast_minute_events_in_chunks(match_id: int, minute: int, duration: int 
 
             # --- Собираем структуру данных ТОЛЬКО с событием и флагом ---
             message_payload = {
-                "type": "match_update", # Тип сообщения для consumer
+                "type": "match_update",  # Тип сообщения для consumer
                 "data": {
-                    "match_id": match_id, # Добавим ID матча
-                    "events": [single_event_data], # Массив с одним событием
-                    "partial_update": True  # Флаг, что это только событие
-                }
+                    "match_id": match_id,
+                    "minute": minute,  # Передаем минуту события явно
+                    "home_score": match.home_score,
+                    "away_score": match.away_score,
+                    "status": match.status,
+                    "st_shoots": match.st_shoots,
+                    "st_passes": match.st_passes,
+                    "st_possessions": match.st_possessions,
+                    "st_fouls": match.st_fouls,
+                    "st_injury": match.st_injury,
+                    "events": [single_event_data],
+                    "partial_update": True,  # Помечаем как частичное обновление
+                },
             }
             # -----------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- include minute, scores and stats in `broadcast_minute_events_in_chunks`
  so the consumer doesn't reload full match state while streaming events
- update JS so scoreboard only changes when a goal event is displayed

## Testing
- `python -m py_compile matches/tasks.py matches/match_simulation.py matches/views.py`