### PR TITLE
Bug fixes and skill-based probabilities

### DIFF
--- a/matches/tasks.py
+++ b/matches/tasks.py
@@ -50,8 +50,6 @@ def simulate_next_minute(match_id: int):
 
             minute = match.current_minute
             match.save()
-            minute = updated.current_minute
-            updated.save()
 
         broadcast_minute_events_in_chunks.delay(match_id, minute)
 

--- a/players/models.py
+++ b/players/models.py
@@ -125,6 +125,8 @@ class Player(models.Model):
     long_range = models.IntegerField(default=0, verbose_name="Long Range")
     vision = models.IntegerField(default=0, verbose_name="Vision")
     accuracy = models.IntegerField(default=0, verbose_name="Accuracy")
+    # New attribute to influence foul probability
+    aggression = models.IntegerField(default=0, verbose_name="Aggression")
 
     # Новое поле опыта
     experience = models.FloatField(default=0.0, verbose_name="Experience")
@@ -150,7 +152,7 @@ class Player(models.Model):
         # Атакующие
         'attacking': ('finishing', 'heading', 'long_range'),
         # Ментальные
-        'mental': ('vision', 'flair'),
+        'mental': ('vision', 'flair', 'aggression'),
         # Технические
         'technical': ('dribbling', 'crossing', 'passing'),
         # Тактические


### PR DESCRIPTION
## Summary
- use `possession_indicator` consistently in simulation
- fix minute simulation task saving logic
- add `aggression` field to `Player`
- compute pass, shot, tackle and foul probabilities from player skills and team tactics

## Testing
- `python manage.py makemigrations players --dry-run --no-input` *(fails: ModuleNotFoundError: No module named 'django')*