### PR TITLE
Fix automatic minute scheduling

### DIFF
--- a/matches/tasks.py
+++ b/matches/tasks.py
@@ -30,7 +30,7 @@ TICK_SECONDS = settings.MATCH_TICK_SECONDS
 # --- Interactive minute simulation task ---
 @shared_task(name="matches.simulate_next_minute")
 def simulate_next_minute(match_id: int):
-    """Simulate one minute, broadcast events and pause the match."""
+    """Simulate one minute and automatically schedule the next."""
     start = time.monotonic()
     try:
         with transaction.atomic():
@@ -44,34 +44,40 @@ def simulate_next_minute(match_id: int):
 
             from .match_simulation import simulate_one_minute
 
+            minute_before = match.current_minute
+
             match = simulate_one_minute(match)
             if not match:
                 logger.error(f"simulate_one_minute failed for match {match_id}")
                 return f"Simulation failed {match_id}"
 
             minute = match.current_minute
+            if minute != minute_before + 1:
+                logger.warning(
+                    f"Match {match_id} minute desync: {minute_before}->{minute}"
+                )
+
             match.save()
 
         broadcast_minute_events_in_chunks.delay(
             match_id, minute, duration=TICK_SECONDS
         )
-            minute = updated.current_minute
-            updated.save()
-
-        broadcast_minute_events_in_chunks.delay(match_id, minute, duration=TICK_SECONDS)
 
         with transaction.atomic():
             match = Match.objects.select_for_update().get(id=match_id)
             if match.current_minute >= 90:
                 match.status = "finished"
+                schedule_next = False
             else:
-                match.status = "paused"
+                match.status = "in_progress"
+                schedule_next = True
             match.save()
 
         elapsed = time.monotonic() - start
-        remain = TICK_SECONDS - elapsed
-        if remain > 0:
-            time.sleep(remain)
+        remain = max(0, TICK_SECONDS - elapsed)
+
+        if schedule_next:
+            simulate_next_minute.apply_async(args=[match_id], countdown=remain)
 
         return f"Minute {minute} done for match {match_id}"
 


### PR DESCRIPTION
## Summary
- protect against double minute calculation in `simulate_next_minute`
- keep match in progress and continue scheduling next minute

## Testing
- `pytest -q` *(fails: pytest not installed)*