### PR TITLE
Implement real-time minute updates

### DIFF
--- a/matches/migrations/0005_match_real_time_fields.py
+++ b/matches/migrations/0005_match_real_time_fields.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('matches', '0004_start_minute_at_one'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='match',
+            name='started_at',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='match',
+            name='last_minute_update',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+    ]

--- a/matches/models.py
+++ b/matches/models.py
@@ -57,6 +57,10 @@ class Match(models.Model):
     # Текущая минута матча
     current_minute = models.PositiveIntegerField(default=1)
 
+    # Метка времени начала матча и последнего обновления минуты
+    started_at = models.DateTimeField(null=True, blank=True)
+    last_minute_update = models.DateTimeField(null=True, blank=True)
+
     # Текущий игрок, владеющий мячом, и текущая зона
     current_player_with_ball = models.ForeignKey(
         Player,

--- a/realfootballsim/settings.py
+++ b/realfootballsim/settings.py
@@ -174,6 +174,10 @@ CELERY_BEAT_SCHEDULE = {
         # Will be overridden in the database to MATCH_MINUTE_REAL_SECONDS
         'schedule': MATCH_MINUTE_REAL_SECONDS,
     },
+    'advance-match-minutes': {
+        'task': 'tournaments.advance_match_minutes',
+        'schedule': 1.0,
+    },
     'check-season-end': {
         'task': 'tournaments.check_season_end',
         'schedule': crontab(hour=0, minute=0),  # Каждый день в полночь

--- a/tournaments/celery_utils.py
+++ b/tournaments/celery_utils.py
@@ -24,3 +24,19 @@ def ensure_simulation_schedule():
         "Celery schedule for simulate-active-matches set to %s seconds",
         settings.MATCH_MINUTE_REAL_SECONDS,
     )
+
+    real_interval, _ = IntervalSchedule.objects.get_or_create(
+        every=1,
+        period=IntervalSchedule.SECONDS,
+    )
+    rt_task, created = PeriodicTask.objects.update_or_create(
+        name='advance-match-minutes',
+        defaults={
+            'task': 'tournaments.advance_match_minutes',
+            'interval': real_interval,
+        },
+    )
+    if not created and rt_task.interval_id != real_interval.id:
+        rt_task.interval = real_interval
+        rt_task.save()
+    logger.info("Celery schedule for advance-match-minutes set to 1 second")


### PR DESCRIPTION
## Summary
- add `started_at` and `last_minute_update` timestamps to matches
- initialize timestamps when scheduled matches begin
- create periodic `advance_match_minutes` task
- schedule new task in Celery beat and helper
- remove minute increments from action simulation

## Testing
- `python manage.py makemigrations --check --dry-run` *(fails: ModuleNotFoundError: No module named 'django')*
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
