### PR TITLE
Implement wait flag for match actions

### DIFF
--- a/matches/migrations/0006_match_waiting_flag.py
+++ b/matches/migrations/0006_match_waiting_flag.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('matches', '0005_match_real_time_fields'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='match',
+            name='waiting_for_next_minute',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/matches/models.py
+++ b/matches/models.py
@@ -61,6 +61,9 @@ class Match(models.Model):
     started_at = models.DateTimeField(null=True, blank=True)
     last_minute_update = models.DateTimeField(null=True, blank=True)
 
+    # Флаг ожидания перехода на следующую минуту
+    waiting_for_next_minute = models.BooleanField(default=False)
+
     # Текущий игрок, владеющий мячом, и текущая зона
     current_player_with_ball = models.ForeignKey(
         Player,


### PR DESCRIPTION
## Summary
- add `waiting_for_next_minute` field to `Match`
- migrate models with new field
- stop action simulation when waiting for the next minute
- clear waiting flag when minutes advance or match starts

## Testing
- `python manage.py test` *(fails: couldn't import Django)*