### PR TITLE
Implement counterattack logic

### DIFF
--- a/matches/match_simulation.py
+++ b/matches/match_simulation.py
@@ -507,14 +507,29 @@ def simulate_one_action(match: Match) -> dict:
                 }
 
                 if interceptor:
+                    special_counter = (
+                        (current_zone == "GK" and target_zone == "DEF") or
+                        (current_zone == "DEF" and target_zone == "DM")
+                    )
+
                     interception_event = {
                         'match': match,
                         'minute': match.current_minute,
-                        'event_type': 'interception',
+                        'event_type': 'counterattack' if special_counter else 'interception',
                         'player': interceptor,
                         'related_player': current_player,
                         'description': f"INTERCEPTION! {interceptor.last_name} ({opponent_team.name}) from {current_player.last_name} in {current_zone}.",
                     }
+
+                    if special_counter:
+                        match.current_player_with_ball = interceptor
+                        match.current_zone = "DM"
+                        return {
+                            'event': pass_event,
+                            'additional_event': interception_event,
+                            'action_type': 'counterattack',
+                            'continue': True
+                        }
 
                     # Мяч переходит к перехватившему или к вратарю его команды
                     new_keeper = choose_player(opponent_team, "GK", match=match)

--- a/matches/migrations/0001_initial.py
+++ b/matches/migrations/0001_initial.py
@@ -50,7 +50,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('minute', models.PositiveIntegerField(db_index=True)),
-                ('event_type', models.CharField(choices=[('goal', 'Goal'), ('pass', 'Pass'), ('interception', 'Interception'), ('shot_miss', 'Shot Miss'), ('foul', 'Foul'), ('injury_concern', 'Injury Concern'), ('info', 'Info'), ('match_start', 'Match Start'), ('half_time', 'Half Time'), ('match_end', 'Match End'), ('match_paused', 'Match Paused'), ('yellow_card', 'Yellow Card'), ('red_card', 'Red Card'), ('substitution', 'Substitution')], db_index=True, max_length=30)),
+                ('event_type', models.CharField(choices=[('goal', 'Goal'), ('pass', 'Pass'), ('interception', 'Interception'), ('counterattack', 'Counterattack'), ('shot_miss', 'Shot Miss'), ('foul', 'Foul'), ('injury_concern', 'Injury Concern'), ('info', 'Info'), ('match_start', 'Match Start'), ('half_time', 'Half Time'), ('match_end', 'Match End'), ('match_paused', 'Match Paused'), ('yellow_card', 'Yellow Card'), ('red_card', 'Red Card'), ('substitution', 'Substitution')], db_index=True, max_length=30)),
                 ('description', models.TextField(blank=True)),
                 ('timestamp', models.DateTimeField(auto_now_add=True, db_index=True)),
                 ('match', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='events', to='matches.match')),

--- a/matches/models.py
+++ b/matches/models.py
@@ -117,6 +117,7 @@ class MatchEvent(models.Model):
             ('goal', 'Goal'),
             ('pass', 'Pass'),
             ('interception', 'Interception'),
+            ('counterattack', 'Counterattack'),
             ('shot_miss', 'Shot Miss'),
             ('foul', 'Foul'),
             ('injury_concern', 'Injury Concern'),

--- a/matches/static/matches/js/live_match.js
+++ b/matches/static/matches/js/live_match.js
@@ -206,6 +206,7 @@ document.addEventListener('DOMContentLoaded', function() {
         let icon = ' M ';
         switch(event.event_type) {
             case 'goal': icon = ' ⚽ '; break;
+            case 'counterattack': icon = ' ⚡ '; break;
             case 'interception': icon = ' 🔄 '; break;
             case 'shot_miss': icon = ' ❌ '; break;
             case 'pass': icon = ' ➡ '; break;

--- a/matches/templates/matches/match_detail.html
+++ b/matches/templates/matches/match_detail.html
@@ -111,7 +111,7 @@
                                         <div class="list-group-item">
                                             {# Отображение начальных событий (можно улучшить формат) #}
                                             <strong>{{ event.minute }}'</strong>
-                                            {% if event.event_type == 'goal' %}⚽{% elif event.event_type == 'interception' %}🔄{% elif event.event_type == 'shot_miss' %}❌{% elif event.event_type == 'pass' %}➡️{% elif event.event_type == 'foul' %}⚠️{% elif event.event_type == 'injury_concern' %}✚{% else %} M {% endif %}
+                                            {% if event.event_type == 'goal' %}⚽{% elif event.event_type == 'counterattack' %}⚡{% elif event.event_type == 'interception' %}🔄{% elif event.event_type == 'shot_miss' %}❌{% elif event.event_type == 'pass' %}➡️{% elif event.event_type == 'foul' %}⚠️{% elif event.event_type == 'injury_concern' %}✚{% else %} M {% endif %}
                                             {{ event.description }}
                                             {# Отображение игроков #}
                                             {% if event.player %}


### PR DESCRIPTION
## Summary
- extend `MatchEvent` choices with a new `counterattack` type
- display counterattacks in match detail HTML and live JS
- handle counterattack interceptions in `simulate_one_action`
- keep migrations consistent

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68407c2844f4832e91a30877e95c06c6