### PR TITLE
Ensure pass events logged for quick counter

### DIFF
--- a/matches/match_simulation.py
+++ b/matches/match_simulation.py
@@ -539,7 +539,8 @@ def simulate_one_action(match: Match) -> dict:
                             # Перехват в зоне защиты соперника – мгновенный пас вперёд
                             match.current_zone = "FWD"
                             return {
-                                'event': interception_event,
+                                'event': pass_event,
+                                'additional_event': interception_event,
                                 'action_type': 'counterattack',
                                 'continue': True
                             }
@@ -576,15 +577,17 @@ def simulate_one_action(match: Match) -> dict:
                                     match.current_player_with_ball = new_keeper
                                     match.current_zone = "GK"
                                 return {
-                                    'event': interception_event,
-                                    'additional_event': shot_event,
+                                    'event': pass_event,
+                                    'additional_event': interception_event,
+                                    'second_additional_event': shot_event,
                                     'action_type': 'counterattack',
                                     'continue': False
                                 }
                             else:
                                 match.current_zone = "FWD"
                                 return {
-                                    'event': interception_event,
+                                    'event': pass_event,
+                                    'additional_event': interception_event,
                                     'action_type': 'counterattack',
                                     'continue': True
                                 }


### PR DESCRIPTION
## Summary
- log failed passes before counterattacks
- broadcast second additional event if present
- test special counterattack logging

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68419f199d58832e93fc4c12262f1b0b