### PR TITLE
Add long pass mechanic with heading influence

### DIFF
--- a/matches/tests.py
+++ b/matches/tests.py
@@ -180,3 +180,60 @@ class CounterPassAfterInterceptionTests(TestCase):
         self.assertEqual(result["additional_event"]["event_type"], "counterattack")
         self.assertIn("second_additional_event", result)
         self.assertEqual(result["second_additional_event"]["event_type"], "pass")
+
+
+class LongPassProbabilityTests(TestCase):
+    def test_heading_affects_long_pass(self):
+        club = Club.objects.create(name="LP", is_bot=True, country=DEFAULT_COUNTRY)
+        opp = Club.objects.create(name="OPP", is_bot=True, country=DEFAULT_COUNTRY)
+
+        passer = Player.objects.create(
+            first_name="P",
+            last_name="P",
+            club=club,
+            position="Central Midfielder",
+            passing=80,
+            vision=80,
+        )
+        recipient_good = Player.objects.create(
+            first_name="R",
+            last_name="H",
+            club=club,
+            position="Center Forward",
+            heading=90,
+            positioning=80,
+        )
+        opponent = Player.objects.create(
+            first_name="O",
+            last_name="O",
+            club=opp,
+            position="Center Back",
+            marking=50,
+            tackling=50,
+        )
+        prob_high = pass_success_probability(
+            passer,
+            recipient_good,
+            opponent,
+            from_zone="DM",
+            to_zone="FWD",
+            high=True,
+        )
+
+        recipient_bad = Player.objects.create(
+            first_name="R2",
+            last_name="L",
+            club=club,
+            position="Center Forward",
+            heading=10,
+            positioning=80,
+        )
+        prob_low = pass_success_probability(
+            passer,
+            recipient_bad,
+            opponent,
+            from_zone="DM",
+            to_zone="FWD",
+            high=True,
+        )
+        self.assertGreater(prob_high, prob_low)


### PR DESCRIPTION
## Summary
- add `ZONE_SEQUENCE` and update `pass_success_probability` to support long/high passes
- give players chance for long passes in `simulate_one_action`
- include recipient heading in long pass chance calculations
- update counter-pass logic after interception
- test heading effect on long pass probability

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684328c90f0c832eb0681974ac52d08b