### PR TITLE
Implement 16 zone grid

### DIFF
--- a/matches/match_simulation.py
+++ b/matches/match_simulation.py
@@ -89,9 +89,9 @@ def zone_conditions(zone: str):
     zone_upper = zone.upper() # Приводим к верхнему регистру для надежности
     if zone_upper == "GK":
         return lambda p: p.position == "Goalkeeper"
-    elif zone_upper == "DEF":
-        return lambda p: "Back" in p.position or "Defender" in p.position or p.position == "CB" or p.position == "LB" or p.position == "RB"
-    elif zone_upper in ["DM", "MID"]:
+    elif zone_upper.startswith("DEF"):
+        return lambda p: "Back" in p.position or "Defender" in p.position or p.position in ["CB", "LB", "RB"]
+    elif zone_upper.startswith("DM") or zone_upper == "MID":
         # Defensive/Central midfielders. The initial logic only handled
         # "Defensive Midfielder" or the short "CM" abbreviation which meant
         # players registered as "Central Midfielder" were ignored. When no
@@ -102,7 +102,7 @@ def zone_conditions(zone: str):
             p.position in ["Defensive Midfielder", "Central Midfielder", "CM"]
             or ("Midfielder" in p.position and "Defensive" in p.position)
         )
-    elif zone_upper == "AM":
+    elif zone_upper.startswith("AM"):
         return lambda p: (
             ("Midfielder" in p.position and "Attacking" in p.position)
             or p.position == "CAM"
@@ -112,24 +112,28 @@ def zone_conditions(zone: str):
         )
     elif zone_upper == "WING":
          return lambda p: p.position in ["LW", "RW", "LM", "RM"]
-    elif zone_upper == "FWD":
+    elif zone_upper.startswith("FWD"):
         return lambda p: "Forward" in p.position or "Striker" in p.position or p.position == "ST" or p.position == "CF"
     else: # 'ANY' или неизвестная зона
         return lambda p: True
 
 def mirrored_zone(zone: str) -> str:
     """Return the zone on the pitch where an opponent would most likely intercept."""
-    mapping = {
-        "GK": "FWD",   # pressing forwards near the goalkeeper
-        "DEF": "AM",   # attackers step up against defenders
-        "DM": "AM",    # attacking mids challenge defensive mids
-        "MID": "MID",  # symmetrical centre of the pitch
-        "AM": "DM",    # defensive mids track attacking mids
-        "FWD": "DEF",  # defenders battle with forwards
-        "WING": "WING", # wingers oppose each other
-        "ANY": "ANY",
+    prefix = zone_prefix(zone)
+    side = zone_side(zone)
+    mirror_map = {
+        "GK": make_zone("FWD", "C"),
+        "DEF": make_zone("AM", side),
+        "DM": make_zone("AM", side),
+        "MID": make_zone("MID", side),
+        "AM": make_zone("DM", side),
+        "FWD": make_zone("DEF", side),
     }
-    return mapping.get(zone.upper(), zone)
+    if prefix in mirror_map:
+        return mirror_map[prefix]
+    if prefix == "WING" or zone.upper() == "WING":
+        return "WING"
+    return zone
 
 def choose_player(team: Club, zone: str, exclude_ids: set = None, match: Match = None) -> Player | None:
     """
@@ -300,7 +304,45 @@ def clamp(value: float, min_value: float = 0.0, max_value: float = 1.0) -> float
     return max(min_value, min(max_value, value))
 
 
-ZONE_SEQUENCE = ["GK", "DEF", "DM", "MID", "AM", "FWD"]
+# --- Expanded 16 zone grid ---
+ZONE_GRID = [
+    "GK",
+    "DEF-L", "DEF-C", "DEF-R",
+    "DM-L", "DM-C", "DM-R",
+    "MID-L", "MID-C", "MID-R",
+    "AM-L", "AM-C", "AM-R",
+    "FWD-L", "FWD-C", "FWD-R",
+]
+
+# Helper mappings to work with the grid
+ROW_PREFIX = ["GK", "DEF", "DM", "MID", "AM", "FWD"]
+ROW_INDEX = {p: i for i, p in enumerate(ROW_PREFIX)}
+
+def zone_prefix(zone: str) -> str:
+    return zone.split("-")[0]
+
+def zone_side(zone: str) -> str:
+    parts = zone.split("-")
+    return parts[1] if len(parts) > 1 else "C"
+
+def make_zone(prefix: str, side: str) -> str:
+    if prefix == "GK":
+        return "GK"
+    return f"{prefix}-{side}"
+
+def next_zone(zone: str) -> str:
+    """Return the next zone forward keeping the same side."""
+    prefix = zone_prefix(zone)
+    side = zone_side(zone)
+    next_map = {
+        "GK": "DEF",
+        "DEF": "DM",
+        "DM": "MID",
+        "MID": "AM",
+        "AM": "FWD",
+        "FWD": "FWD",
+    }
+    return make_zone(next_map.get(prefix, prefix), side)
 
 
 def pass_success_probability(
@@ -313,20 +355,25 @@ def pass_success_probability(
     high: bool = False,
 ) -> float:
     """Return probability that a pass succeeds for a given zone transition."""
-    zone_base = {
-        ("GK", "DEF"): 0.9,
-        ("DEF", "DM"): 0.8,
-        ("DM", "MID"): 0.75,
-        ("MID", "AM"): 0.7,
-        ("AM", "FWD"): 0.65,
-    }
-
-    base = zone_base.get((from_zone, to_zone), 0.6)
+    f_prefix = zone_prefix(from_zone)
+    t_prefix = zone_prefix(to_zone)
+    def_base = 0.6
+    if f_prefix == "GK" and t_prefix == "DEF":
+        def_base = 0.9
+    elif f_prefix == "DEF" and t_prefix == "DM":
+        def_base = 0.8
+    elif f_prefix == "DM" and t_prefix == "MID":
+        def_base = 0.75
+    elif f_prefix == "MID" and t_prefix == "AM":
+        def_base = 0.7
+    elif f_prefix == "AM" and t_prefix == "FWD":
+        def_base = 0.65
+    base = def_base
 
     if high:
         try:
-            distance = ZONE_SEQUENCE.index(to_zone) - ZONE_SEQUENCE.index(from_zone)
-        except ValueError:
+            distance = ROW_INDEX[t_prefix] - ROW_INDEX[f_prefix]
+        except Exception:
             distance = 1
         base -= 0.05 * max(distance - 1, 0)
 
@@ -432,7 +479,7 @@ def simulate_one_action(match: Match) -> dict:
     
     
     # Основная логика действия в зависимости от зоны
-    if current_zone == "FWD":
+    if zone_prefix(current_zone) == "FWD":
         # Зона атаки - удар по воротам
         match.st_shoots += 1
         shooter = current_player
@@ -476,22 +523,15 @@ def simulate_one_action(match: Match) -> dict:
         }
     
     else:
-        # Попытка паса в следующую зону
-        transition_map = {
-            "GK": "DEF",
-            "DEF": "DM", 
-            "DM": "MID",
-            "MID": "AM",
-            "AM": "FWD"
-        }
-        
-        target_zone = transition_map.get(current_zone, current_zone)
+        # Attempt a pass to the next zone keeping the same side
+        target_zone = next_zone(current_zone)
         is_long = False
-        zone_index = ZONE_SEQUENCE.index(current_zone)
-        available_steps = len(ZONE_SEQUENCE) - zone_index - 1
-        if available_steps > 1 and random.random() < 0.2:
-            steps = random.randint(2, min(3, available_steps))
-            target_zone = ZONE_SEQUENCE[zone_index + steps]
+        current_row = ROW_INDEX.get(zone_prefix(current_zone), 0)
+        available_rows = len(ROW_PREFIX) - 1 - current_row
+        if available_rows > 1 and random.random() < 0.2:
+            steps = random.randint(2, min(3, available_rows))
+            next_row = current_row + steps
+            target_zone = make_zone(ROW_PREFIX[next_row], zone_side(current_zone))
             is_long = True
 
         match.st_possessions += 1

--- a/matches/migrations/0009_expand_zones.py
+++ b/matches/migrations/0009_expand_zones.py
@@ -1,0 +1,63 @@
+from django.db import migrations, models
+
+
+def forwards(apps, schema_editor):
+    Match = apps.get_model('matches', 'Match')
+    for match in Match.objects.all():
+        z = match.current_zone
+        mapping = {
+            'DEF': 'DEF-C',
+            'DM': 'DM-C',
+            'MID': 'MID-C',
+            'AM': 'AM-C',
+            'FWD': 'FWD-C',
+        }
+        if z in mapping:
+            match.current_zone = mapping[z]
+            match.save(update_fields=['current_zone'])
+
+
+def backwards(apps, schema_editor):
+    Match = apps.get_model('matches', 'Match')
+    for match in Match.objects.all():
+        z = match.current_zone
+        if z.startswith('DEF'):
+            match.current_zone = 'DEF'
+        elif z.startswith('DM'):
+            match.current_zone = 'DM'
+        elif z.startswith('MID'):
+            match.current_zone = 'MID'
+        elif z.startswith('AM'):
+            match.current_zone = 'AM'
+        elif z.startswith('FWD'):
+            match.current_zone = 'FWD'
+        match.save(update_fields=['current_zone'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('matches', '0008_add_dribble_event_type'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='match',
+            name='current_zone',
+            field=models.CharField(
+                max_length=10,
+                choices=[
+                    ('GK', 'GK'),
+                    ('DEF-L', 'DEF-L'), ('DEF-C', 'DEF-C'), ('DEF-R', 'DEF-R'),
+                    ('DM-L', 'DM-L'), ('DM-C', 'DM-C'), ('DM-R', 'DM-R'),
+                    ('MID-L', 'MID-L'), ('MID-C', 'MID-C'), ('MID-R', 'MID-R'),
+                    ('AM-L', 'AM-L'), ('AM-C', 'AM-C'), ('AM-R', 'AM-R'),
+                    ('FWD-L', 'FWD-L'), ('FWD-C', 'FWD-C'), ('FWD-R', 'FWD-R'),
+                ],
+                default='GK',
+                verbose_name='Current Zone',
+            ),
+        ),
+        migrations.RunPython(forwards, backwards),
+    ]
+

--- a/matches/models.py
+++ b/matches/models.py
@@ -77,13 +77,13 @@ class Match(models.Model):
         max_length=10,
         choices=[
             ('GK', 'GK'),
-            ('DEF', 'DEF'),
-            ('DM', 'DM'),
-            ('MID', 'MID'),
-            ('AM', 'AM'),
-            ('FWD', 'FWD')
+            ('DEF-L', 'DEF-L'), ('DEF-C', 'DEF-C'), ('DEF-R', 'DEF-R'),
+            ('DM-L', 'DM-L'), ('DM-C', 'DM-C'), ('DM-R', 'DM-R'),
+            ('MID-L', 'MID-L'), ('MID-C', 'MID-C'), ('MID-R', 'MID-R'),
+            ('AM-L', 'AM-L'), ('AM-C', 'AM-C'), ('AM-R', 'AM-R'),
+            ('FWD-L', 'FWD-L'), ('FWD-C', 'FWD-C'), ('FWD-R', 'FWD-R'),
         ],
-        default='GK', # Убедитесь, что GK - подходящее значение по умолчанию
+        default='GK',
         verbose_name="Current Zone"
     )
 

--- a/matches/tests.py
+++ b/matches/tests.py
@@ -86,7 +86,7 @@ class DMRecipientTests(TestCase):
         for _ in range(50):
             recipient = choose_player(
                 self.home,
-                "DM",
+                "DM-C",
                 exclude_ids={defender.id},
                 match=self.match,
             )
@@ -118,7 +118,7 @@ class SpecialCounterLoggingTests(TestCase):
     def test_pass_event_returned_for_special_counter(self):
         def choose_stub(team, zone, exclude_ids=None, match=None):
             if team == self.home:
-                return self.home_def if zone == "DEF" else self.home_gk
+                return self.home_def if zone == "DEF-C" else self.home_gk
             else:
                 return self.away_gk if zone == "GK" else self.away_def
 
@@ -150,15 +150,15 @@ class CounterPassAfterInterceptionTests(TestCase):
             away_lineup={"0": {"playerId": str(self.away_gk.id)}, "1": {"playerId": str(self.away_def.id)}, "2": {"playerId": str(self.away_fwd.id)}}
         )
         self.match.current_player_with_ball = self.home_def
-        self.match.current_zone = "DEF"
+        self.match.current_zone = "DEF-C"
         self.match.save()
 
     def test_counter_pass_created_when_no_long_shot(self):
         def choose_stub(team, zone, exclude_ids=None, match=None):
             if team == self.home:
-                if zone == "DM":
+                if zone == "DM-C":
                     return self.home_dm
-                if zone == "DEF":
+                if zone == "DEF-C":
                     return self.home_def
                 if zone == "GK":
                     return self.home_gk
@@ -166,9 +166,9 @@ class CounterPassAfterInterceptionTests(TestCase):
             else:
                 if zone == "GK":
                     return self.away_gk
-                if zone == "DEF":
+                if zone == "DEF-C":
                     return self.away_def
-                if zone == "FWD":
+                if zone == "FWD-C":
                     return self.away_fwd
                 return self.away_def
 
@@ -215,8 +215,8 @@ class LongPassProbabilityTests(TestCase):
             passer,
             recipient_good,
             opponent,
-            from_zone="DM",
-            to_zone="FWD",
+            from_zone="DM-C",
+            to_zone="FWD-C",
             high=True,
         )
 
@@ -232,8 +232,8 @@ class LongPassProbabilityTests(TestCase):
             passer,
             recipient_bad,
             opponent,
-            from_zone="DM",
-            to_zone="FWD",
+            from_zone="DM-C",
+            to_zone="FWD-C",
             high=True,
         )
         self.assertGreater(prob_high, prob_low)


### PR DESCRIPTION
## Summary
- expand pitch model to use 16 zones instead of six
- update helper logic and pass mechanics for new grid
- migrate Match.current_zone to new choices
- adjust tests to new zone names

## Testing
- `python manage.py test matches.tests.DMRecipientTests.matches` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6844766b95b0832ea8ad121d70024b4e