### PR TITLE
Fix player age generation for initial clubs and commands

### DIFF
--- a/clubs/views.py
+++ b/clubs/views.py
@@ -155,7 +155,8 @@ class CreateClubView(CreateView):
                 first_name=first_name,
                 last_name=last_name,
                 nationality=club.country,
-                age=random.randint(18, 30),
+                # Новые игроки начального состава всегда 17 лет
+                age=17,
                 position=player_info["position"],
                 player_class=player_info["class"],
                 **stats
@@ -236,12 +237,13 @@ def create_player(request, pk):
     try:
         stats = generate_player_stats(position, player_class)
 
+        player_age = 17 if player_class in [1, 2, 3, 4] else random.randint(17, 35)
         player = Player.objects.create(
             club=club,
             first_name=first_name,
             last_name=last_name,
             nationality=club.country,
-            age=random.randint(17, 35),
+            age=player_age,
             position=position,
             player_class=player_class,
             **stats

--- a/tournaments/management/commands/generate_players_for_all_teams.py
+++ b/tournaments/management/commands/generate_players_for_all_teams.py
@@ -70,7 +70,8 @@ class Command(BaseCommand):
                 first_name=first_name,
                 last_name=last_name,
                 nationality=club.country,
-                age=random.randint(17, 35),
+                # Игроки классов 1-4 должны быть 17 лет
+                age=17,
                 position=position,
                 player_class=random.randint(1, 4),
                 strength=stats['strength'],
@@ -91,7 +92,8 @@ class Command(BaseCommand):
                 first_name=first_name,
                 last_name=last_name,
                 nationality=club.country,
-                age=random.randint(17, 35),
+                # Игроки классов 1-4 должны быть 17 лет
+                age=17,
                 position=position,
                 player_class=random.randint(1, 4),
                 strength=stats['strength'],

--- a/tournaments/management/commands/initialize_football_world.py
+++ b/tournaments/management/commands/initialize_football_world.py
@@ -182,7 +182,8 @@ class Command(BaseCommand):
             'first_name': first_name,
             'last_name': last_name,
             'nationality': club.country,
-            'age': random.randint(17, 35),
+            # Игроки классов 1-4 должны быть 17 лет
+            'age': 17 if player_class in [1, 2, 3, 4] else random.randint(17, 35),
             'position': position,
             'player_class': player_class,
             'strength': stats['strength'],


### PR DESCRIPTION
## Summary
- ensure new players in a freshly created club are always 17 years old
- keep age at 17 for manual player creation if class is 1–4
- update management commands to generate 17‑year‑olds for classes 1–4

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684563445f28832e832c1cdfb52f1cda