### PR TITLE
Implement basic momentum system

### DIFF
--- a/matches/migrations/0010_momentum.py
+++ b/matches/migrations/0010_momentum.py
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('matches', '0009_expand_zones'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='match',
+            name='home_momentum',
+            field=models.IntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name='match',
+            name='away_momentum',
+            field=models.IntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name='match',
+            name='home_pass_streak',
+            field=models.PositiveIntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name='match',
+            name='away_pass_streak',
+            field=models.PositiveIntegerField(default=0),
+        ),
+    ]

--- a/matches/models.py
+++ b/matches/models.py
@@ -98,6 +98,12 @@ class Match(models.Model):
     # Поле для травм - просто счетчик? Если да, ок. Если нужны детали, лучше JSONField или отдельная модель.
     st_injury = models.PositiveIntegerField(default=0, verbose_name="Injuries Count")
 
+    # Momentum and pass streaks
+    home_momentum = models.IntegerField(default=0)
+    away_momentum = models.IntegerField(default=0)
+    home_pass_streak = models.PositiveIntegerField(default=0)
+    away_pass_streak = models.PositiveIntegerField(default=0)
+
     def __str__(self):
         dt_str = timezone.localtime(self.datetime).strftime('%d.%m.%Y %H:%M') if self.datetime else "N/A" # Локальное время
         return f"{self.home_team.name} vs {self.away_team.name} ({dt_str}) - {self.get_status_display()}" # Используем get_status_display

--- a/matches/tests.py
+++ b/matches/tests.py
@@ -218,6 +218,7 @@ class LongPassProbabilityTests(TestCase):
             from_zone="DM-C",
             to_zone="FWD-C",
             high=True,
+            momentum=0,
         )
 
         recipient_bad = Player.objects.create(
@@ -235,6 +236,7 @@ class LongPassProbabilityTests(TestCase):
             from_zone="DM-C",
             to_zone="FWD-C",
             high=True,
+            momentum=0,
         )
         self.assertGreater(prob_high, prob_low)
 
@@ -278,6 +280,6 @@ class DribbleProbabilityTests(TestCase):
 
         from matches.match_simulation import dribble_success_probability
 
-        prob_good = dribble_success_probability(dribbler_good, defender)
-        prob_bad = dribble_success_probability(dribbler_bad, defender)
+        prob_good = dribble_success_probability(dribbler_good, defender, momentum=0)
+        prob_bad = dribble_success_probability(dribbler_bad, defender, momentum=0)
         self.assertGreater(prob_good, prob_bad)

--- a/tournaments/tasks.py
+++ b/tournaments/tasks.py
@@ -111,6 +111,8 @@ def simulate_active_matches(self):
                                 "st_possessions": match_locked.st_possessions,
                                 "st_fouls": match_locked.st_fouls,
                                 "st_injury": match_locked.st_injury,
+                                "home_momentum": match_locked.home_momentum,
+                                "away_momentum": match_locked.away_momentum,
                                 "events": [event_data],
                                 "partial_update": True,
                                 "action_based": True  # Новый флаг для пошаговой симуляции
@@ -152,6 +154,8 @@ def simulate_active_matches(self):
                                 "st_possessions": match_locked.st_possessions,
                                 "st_fouls": match_locked.st_fouls,
                                 "st_injury": match_locked.st_injury,
+                                "home_momentum": match_locked.home_momentum,
+                                "away_momentum": match_locked.away_momentum,
                                 "events": [add_event_data],
                                 "partial_update": True,
                                 "action_based": True
@@ -188,6 +192,8 @@ def simulate_active_matches(self):
                                 "st_possessions": match_locked.st_possessions,
                                 "st_fouls": match_locked.st_fouls,
                                 "st_injury": match_locked.st_injury,
+                                "home_momentum": match_locked.home_momentum,
+                                "away_momentum": match_locked.away_momentum,
                                 "events": [add_event_data2],
                                 "partial_update": True,
                                 "action_based": True
@@ -590,6 +596,8 @@ def advance_match_minutes():
                         "st_possessions": match.st_possessions,
                         "st_fouls": match.st_fouls,
                         "st_injury": match.st_injury,
+                        "home_momentum": match.home_momentum,
+                        "away_momentum": match.away_momentum,
                         "events": [info_event_data],
                         "partial_update": True,
                         "action_based": True,


### PR DESCRIPTION
## Summary
- add momentum and pass streak fields to match model
- expose momentum stats in WebSocket updates
- adjust probability helpers to consider team momentum
- update goal logic to modify momentum
- include new migration

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68458acb38e4832e825974f2d2e28ee1