### PR TITLE
Add dynamic momentum display

### DIFF
--- a/matches/match_simulation.py
+++ b/matches/match_simulation.py
@@ -546,6 +546,10 @@ def simulate_one_action(match: Match) -> dict:
     
     # Обновляем индикатор владения
     match.possession_indicator = 1 if possessing_team.id == match.home_team_id else 2
+
+    opponent_team = get_opponent_team(match, possessing_team)
+    update_momentum(match, possessing_team, 1)
+    update_momentum(match, opponent_team, -1)
     
     
     # Основная логика действия в зависимости от зоны

--- a/matches/static/matches/js/live_match.js
+++ b/matches/static/matches/js/live_match.js
@@ -71,6 +71,8 @@ document.addEventListener('DOMContentLoaded', function() {
     const statBox = document.querySelector('.stat-box'); // Блок для статистики
     const homeMomentumIcon = document.getElementById('homeMomentumIcon');
     const awayMomentumIcon = document.getElementById('awayMomentumIcon');
+    const homeMomentumValue = document.getElementById('homeMomentumValue');
+    const awayMomentumValue = document.getElementById('awayMomentumValue');
     const injuryActionForm = document.querySelector('#matchUserAction-inj'); // Форма для травмы
     const nextMinuteBtn = document.getElementById('nextMinuteBtn');
     // Duration of one simulated minute in real seconds
@@ -175,7 +177,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     // --- Функция обновления индикатора моментума ---
-    function setMomentum(el, value) {
+    function setMomentum(el, value, valueEl) {
         if (!el) return;
         el.className = 'momentum-icon';
         let icon = '😐';
@@ -187,11 +189,12 @@ document.addEventListener('DOMContentLoaded', function() {
         else if (value <= -25) { icon = '😰'; el.classList.add('momentum-nervous'); }
         else { el.classList.add('momentum-neutral'); }
         el.textContent = icon;
+        if (valueEl) valueEl.textContent = value;
     }
 
     function updateMomentum(data) {
-        if (data.home_momentum !== undefined) setMomentum(homeMomentumIcon, data.home_momentum);
-        if (data.away_momentum !== undefined) setMomentum(awayMomentumIcon, data.away_momentum);
+        if (data.home_momentum !== undefined) setMomentum(homeMomentumIcon, data.home_momentum, homeMomentumValue);
+        if (data.away_momentum !== undefined) setMomentum(awayMomentumIcon, data.away_momentum, awayMomentumValue);
     }
 
     // --- Функция добавления одного события в лог (теперь добавляет в начало для обратного порядка) ---

--- a/matches/templates/matches/match_detail.html
+++ b/matches/templates/matches/match_detail.html
@@ -83,10 +83,12 @@
                         <div class="row mt-2">
                             <div class="col-5 text-start">
                                 <span id="homeMomentumIcon" class="momentum-icon momentum-neutral">😐</span>
+                                <span id="homeMomentumValue" class="momentum-value">{{ match.home_momentum }}</span>
                             </div>
                             <div class="col-2"></div>
                             <div class="col-5 text-end">
                                 <span id="awayMomentumIcon" class="momentum-icon momentum-neutral">😐</span>
+                                <span id="awayMomentumValue" class="momentum-value">{{ match.away_momentum }}</span>
                             </div>
                         </div>
                     </div>
@@ -389,6 +391,10 @@
     .momentum-nervous { color: #fd7e14; }
     .momentum-demoralized { color: #dc3545; }
     .momentum-panic { color: #721c24; }
+    .momentum-value {
+        font-weight: bold;
+        margin-left: 0.25rem;
+    }
 
     /* Форма реакции на травму */
     .matchUserAction {


### PR DESCRIPTION
## Summary
- show home/away momentum values next to icons
- update JS to refresh values when websocket data arrives
- bump momentum a bit with every action

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845a51df934832e8720e0a347550293