### PR TITLE
Fix live match script loading for scheduled games

### DIFF
--- a/matches/templates/matches/match_detail.html
+++ b/matches/templates/matches/match_detail.html
@@ -314,8 +314,8 @@
 {% block extra_js %}
 {# Подключаем внешние скрипты #}
 <script src="{% static 'matches/js/match_replay.js' %}"></script> {# Если есть скрипт реплея #}
-{% if match.status == 'in_progress' %}
-    {# Подключаем основной скрипт только если матч идет #}
+{# Подключаем основной скрипт для незавершенных матчей #}
+{% if match.status != 'finished' and match.status != 'cancelled' and match.status != 'error' %}
     <script src="{% static 'matches/js/live_match.js' %}"></script>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- ensure `live_match.js` loads for matches that haven't started yet so WebSocket updates flow without refreshing

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6847164fa49c832eb435a64d14f09145