### PR TITLE
Add forward dribble zone logic

### DIFF
--- a/matches/tests/test_dribble_interception.py
+++ b/matches/tests/test_dribble_interception.py
@@ -43,7 +43,7 @@ class DribbleInterceptionTests(TestCase):
         return None
 
     def test_failed_dribble_moves_ball_to_defender(self):
-        with patch("matches.match_simulation.random_adjacent_zone", return_value="DM-R"):
+        with patch("matches.match_simulation.forward_dribble_zone", return_value="DM-R"):
             with patch("matches.match_simulation.choose_player", side_effect=self.choose_mock):
                 with patch("matches.match_simulation.random.random", side_effect=[0.0, 0.9]):
                     with patch("matches.match_simulation.dribble_success_probability", return_value=0.0):


### PR DESCRIPTION
## Summary
- create `forward_dribble_zone` helper to move dribbling forward with small diagonal chance
- use the helper in `simulate_one_action`
- update dribble interception test to patch new helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684d9af75cf8832eb0ff9c511a6839b6