### PR TITLE
Add interception and counterattack events

### DIFF
--- a/matches/match_simulation.py
+++ b/matches/match_simulation.py
@@ -895,18 +895,29 @@ def simulate_one_action(match: Match) -> dict:
                         (zone_prefix(current_zone) == "GK" and zone_prefix(target_zone) == "DM")
                     )
 
-                    interception_type = 'counterattack' if special_counter else 'interception'
                     interception_event = {
                         'match': match,
                         'minute': match.current_minute,
-                        'event_type': interception_type,
+                        'event_type': 'interception',
                         'player': interceptor,
                         'related_player': current_player,
                         'description': render_comment(
-                            interception_type if special_counter else 'interception',
+                            'interception',
                             interceptor=interceptor.last_name,
                             player=current_player.last_name,
                             zone=target_zone,
+                        ),
+                    }
+
+                    counterattack_event = {
+                        'match': match,
+                        'minute': match.current_minute,
+                        'event_type': 'counterattack',
+                        'player': interceptor,
+                        'related_player': current_player,
+                        'description': render_comment(
+                            'counterattack',
+                            interceptor=interceptor.last_name,
                         ),
                     }
 
@@ -918,6 +929,7 @@ def simulate_one_action(match: Match) -> dict:
                             return {
                                 'event': pass_event,
                                 'additional_event': interception_event,
+                                'second_additional_event': counterattack_event,
                                 'action_type': 'counterattack',
                                 'continue': True
                             }
@@ -969,7 +981,8 @@ def simulate_one_action(match: Match) -> dict:
                                 return {
                                     'event': pass_event,
                                     'additional_event': interception_event,
-                                    'second_additional_event': shot_event,
+                                    'second_additional_event': counterattack_event,
+                                    'third_additional_event': shot_event,
                                     'action_type': 'counterattack',
                                     'continue': False
                                 }
@@ -1018,7 +1031,8 @@ def simulate_one_action(match: Match) -> dict:
                                     return {
                                         'event': pass_event,
                                         'additional_event': interception_event,
-                                        'second_additional_event': counter_pass_event,
+                                        'second_additional_event': counterattack_event,
+                                        'third_additional_event': counter_pass_event,
                                         'action_type': 'counterattack',
                                         'continue': True
                                     }
@@ -1061,7 +1075,8 @@ def simulate_one_action(match: Match) -> dict:
                                         return {
                                             'event': pass_event,
                                             'additional_event': interception_event,
-                                            'second_additional_event': interception2_event,
+                                            'second_additional_event': counterattack_event,
+                                            'third_additional_event': interception2_event,
                                             'action_type': 'counterattack',
                                             'continue': False
                                         }
@@ -1071,6 +1086,7 @@ def simulate_one_action(match: Match) -> dict:
                                         return {
                                             'event': pass_event,
                                             'additional_event': interception_event,
+                                            'second_additional_event': counterattack_event,
                                             'action_type': 'counterattack',
                                             'continue': True
                                         }

--- a/matches/static/matches/js/live_match.js
+++ b/matches/static/matches/js/live_match.js
@@ -239,14 +239,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
                 // если событие есть — выводим
                 if (d.events && Array.isArray(d.events) && d.events.length > 0) {
-                    const ev = d.events[0];
-                    addEventToList(ev);
-
-                    // обновляем счёт только при голе
-                    if (ev.event_type === 'goal') {
-                        if (d.home_score !== undefined) homeScoreElement.textContent = d.home_score;
-                        if (d.away_score !== undefined) awayScoreElement.textContent = d.away_score;
-                    }
+                    d.events.forEach(ev => {
+                        addEventToList(ev);
+                        if (ev.event_type === 'goal') {
+                            if (d.home_score !== undefined) homeScoreElement.textContent = d.home_score;
+                            if (d.away_score !== undefined) awayScoreElement.textContent = d.away_score;
+                        }
+                    });
                 }
 
                 // время

--- a/matches/tests/test_gkdm_counterattack.py
+++ b/matches/tests/test_gkdm_counterattack.py
@@ -93,8 +93,10 @@ class GKAllZonesCounterattackTests(TestCase):
 
                 debug_msg = (
                     f"[DEBUG] Пас GK → {tz}. "
-                    f"Контратака: {result.get('additional_event', {}).get('event_type') == 'counterattack'}"
+                    f"Интерцепт: {result.get('additional_event', {}).get('event_type')}"
+                    f", контратака: {result.get('second_additional_event', {}).get('event_type')}"
                 )
                 print(debug_msg)
 
-                self.assertEqual(result["additional_event"]["event_type"], "counterattack")
+                self.assertEqual(result["additional_event"]["event_type"], "interception")
+                self.assertEqual(result["second_additional_event"]["event_type"], "counterattack")


### PR DESCRIPTION
## Summary
- create separate interception and counterattack events in simulation
- send up to three additional events from Celery tasks
- display all events in live commentary
- update counterattack test for new events

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6852ff83ec38832e841c052e85684a7d