### PR TITLE
Enable counterattacks on dribble interceptions

### DIFF
--- a/matches/match_simulation.py
+++ b/matches/match_simulation.py
@@ -777,18 +777,43 @@ def simulate_one_action(match: Match) -> dict:
                             zone=target_zone,
                         ),
                     }
+                    # Counterattack even on failed dribbles in DEF/DM zones
+                    special_counter_dribble = zone_prefix(target_zone) in {"DEF", "DM"}
+
                     new_defender = choose_player(opponent_team, make_zone("DEF", zone_side(target_zone)), match=match)
                     if new_defender:
                         match.current_player_with_ball = new_defender
                     else:
                         match.current_player_with_ball = defender
                     match.current_zone = make_zone("DEF", zone_side(target_zone))
-                    return {
-                        'event': dribble_event,
-                        'additional_event': interception_event,
-                        'action_type': 'interception',
-                        'continue': False,
+
+                    counterattack_event = {
+                        'match': match,
+                        'minute': match.current_minute,
+                        'event_type': 'counterattack',
+                        'player': defender,
+                        'related_player': current_player,
+                        'description': render_comment(
+                            'counterattack',
+                            interceptor=defender.last_name,
+                        ),
                     }
+
+                    if special_counter_dribble:
+                        return {
+                            'event': dribble_event,
+                            'additional_event': interception_event,
+                            'second_additional_event': counterattack_event,
+                            'action_type': 'counterattack',
+                            'continue': True,
+                        }
+                    else:
+                        return {
+                            'event': dribble_event,
+                            'additional_event': interception_event,
+                            'action_type': 'interception',
+                            'continue': False,
+                        }
                 else:
                     return {
                         'event': dribble_event,

--- a/matches/tests/test_dribble_interception.py
+++ b/matches/tests/test_dribble_interception.py
@@ -51,3 +51,23 @@ class DribbleInterceptionTests(TestCase):
         self.assertEqual(result["action_type"], "interception")
         self.assertEqual(self.match.current_zone, "DEF-R")
         self.assertEqual(self.match.current_player_with_ball, self.defender)
+
+    def test_failed_dribble_triggers_counterattack_in_dm(self):
+        """Counterattack event is generated when interception happens in DM."""
+        with patch("matches.match_simulation.forward_dribble_zone", return_value="DM-R"):
+            with patch("matches.match_simulation.choose_player", side_effect=self.choose_mock):
+                with patch("matches.match_simulation.random.random", side_effect=[0.0, 0.9]):
+                    with patch("matches.match_simulation.dribble_success_probability", return_value=0.0):
+                        result = simulate_one_action(self.match)
+        self.assertEqual(result["second_additional_event"]["event_type"], "counterattack")
+        self.assertEqual(result["action_type"], "counterattack")
+
+    def test_failed_dribble_triggers_counterattack_in_def(self):
+        """Counterattack when the ball is lost in DEF zone."""
+        with patch("matches.match_simulation.forward_dribble_zone", return_value="DEF-R"):
+            with patch("matches.match_simulation.choose_player", side_effect=self.choose_mock):
+                with patch("matches.match_simulation.random.random", side_effect=[0.0, 0.9]):
+                    with patch("matches.match_simulation.dribble_success_probability", return_value=0.0):
+                        result = simulate_one_action(self.match)
+        self.assertEqual(result["second_additional_event"]["event_type"], "counterattack")
+        self.assertEqual(result["action_type"], "counterattack")


### PR DESCRIPTION
## Summary
- generate `counterattack` events when a dribble is intercepted in DEF or DM zones
- test dribble interceptions triggering counterattacks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6854de0e3748832e86022fce33d24b87