### PR TITLE
Add live pitch zones display

### DIFF
--- a/matches/static/matches/js/live_match.js
+++ b/matches/static/matches/js/live_match.js
@@ -77,6 +77,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const awayMomentumValue  = document.getElementById('awayMomentumValue');
     const injuryActionForm   = document.querySelector('#matchUserAction-inj');
     const nextMinuteBtn      = document.getElementById('nextMinuteBtn');
+    const pitchEl            = document.getElementById('pitch');
 
     // --- Защитные проверки на наличие ключевых узлов --------------------------
     if (!timeElement)      console.error('Element #matchTime not found!');
@@ -92,6 +93,33 @@ document.addEventListener('DOMContentLoaded', () => {
     // Показ сообщений пользователю (упрощённое, выводит в консоль)
     function showMessage(text, type = 'info') {
         console.log(`MESSAGE (${type}): ${text}`);
+    }
+
+    function highlight(zoneName) {
+        if (!pitchEl) return;
+        document.querySelectorAll('#pitch .zone').forEach(z => {
+            if (z.dataset.zone === zoneName) z.classList.add('active');
+            else z.classList.remove('active');
+        });
+    }
+
+    function showIcon(zoneName, type) {
+        if (!pitchEl) return;
+        const icons = {
+            goal: '⚽', shot: '⚽', shot_miss: '❌', pass: '➡️',
+            interception: '🔄', foul: '⚠️', counterattack: '⚡', dribble: '↕️'
+        };
+        const cell = document.querySelector(`#pitch .zone[data-zone="${zoneName}"]`);
+        if (!cell) return;
+        let ico = cell.querySelector('.event-icon');
+        if (!ico) {
+            ico = document.createElement('span');
+            ico.className = 'event-icon';
+            cell.appendChild(ico);
+        }
+        ico.textContent = icons[type] || '';
+        clearTimeout(ico._timer);
+        ico._timer = setTimeout(() => ico.remove(), 2000);
     }
 
     // Обновление HTML‑иконки и числа моментума
@@ -204,6 +232,10 @@ function addEventToList(evt) {
         processingQueue = true;
         const item = eventQueue.shift();
         addEventToList(item.event);
+        if (item.data.current_zone) {
+            highlight(item.data.current_zone);
+            showIcon(item.data.current_zone, item.event.event_type);
+        }
         if (item.event.event_type === 'goal') {
             if (item.data.home_score !== undefined) homeScoreElement.textContent = item.data.home_score;
             if (item.data.away_score !== undefined) awayScoreElement.textContent = item.data.away_score;
@@ -246,6 +278,7 @@ function addEventToList(evt) {
             const msg  = JSON.parse(e.data);
             if (msg.type !== 'match_update' || !msg.data) return;
             const d = msg.data;
+            if (d.current_zone) highlight(d.current_zone);
             console.log('WS data:', d);
 
             // 1) Первое сообщение: полный стейт + история

--- a/matches/templates/matches/match_detail.html
+++ b/matches/templates/matches/match_detail.html
@@ -93,6 +93,32 @@
                         </div>
                     </div>
 
+                    <div id="pitch" class="my-3">
+                        <div class="zone" data-zone="GK"></div>
+                        <div class="zone" data-zone="GK"></div>
+                        <div class="zone" data-zone="GK"></div>
+
+                        <div class="zone" data-zone="DEF-L">DEF‑L</div>
+                        <div class="zone" data-zone="DEF-C">DEF‑C</div>
+                        <div class="zone" data-zone="DEF-R">DEF‑R</div>
+
+                        <div class="zone" data-zone="DM-L">DM‑L</div>
+                        <div class="zone" data-zone="DM-C">DM‑C</div>
+                        <div class="zone" data-zone="DM-R">DM‑R</div>
+
+                        <div class="zone" data-zone="MID-L">MID‑L</div>
+                        <div class="zone" data-zone="MID-C">MID‑C</div>
+                        <div class="zone" data-zone="MID-R">MID‑R</div>
+
+                        <div class="zone" data-zone="AM-L">AM‑L</div>
+                        <div class="zone" data-zone="AM-C">AM‑C</div>
+                        <div class="zone" data-zone="AM-R">AM‑R</div>
+
+                        <div class="zone" data-zone="FWD-L">FWD‑L</div>
+                        <div class="zone" data-zone="FWD-C">FWD‑C</div>
+                        <div class="zone" data-zone="FWD-R">FWD‑R</div>
+                    </div>
+
                     <!-- Кнопка Replay, если матч завершён -->
                     {% if match.status == 'finished' %}
                     <div class="text-center mb-3"> {# Центрируем кнопку #}
@@ -416,6 +442,39 @@
     .table-sm th, .table-sm td {
         padding: 0.4rem;
         font-size: 0.9em;
+    }
+
+    /* Pitch visualization */
+    #pitch {
+        width: 100%;
+        max-width: 600px;
+        height: 350px;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        grid-template-rows: repeat(6, 1fr);
+        background: #228B22;
+        border: 2px solid #fff;
+        position: relative;
+    }
+    #pitch .zone {
+        border: 1px solid #fff;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        color: #fff;
+        position: relative;
+        font-size: 12px;
+    }
+    #pitch .zone.active {
+        background: rgba(255,255,0,0.4);
+    }
+    #pitch .event-icon {
+        position: absolute;
+        font-size: 20px;
+        top: 2px;
+        right: 2px;
+        pointer-events: none;
     }
 </style>
 


### PR DESCRIPTION
## Summary
- embed horizontal pitch layout on the match detail page
- style zones and event icons
- highlight pitch zones in real time via WebSocket

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68614896e988832eb50c36a2df8b98e0