### PR TITLE
Improve match minute advancement reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ This is a Django based football simulator featuring live match updates, player m
 3. **Environment variables**
    - `IS_PRODUCTION` – set to `1` to enable production settings.
    - `MATCH_MINUTE_REAL_SECONDS` – real seconds that represent one simulated minute (default: `60`).
+   - `MATCH_MINUTE_FORCE_ADVANCE_SECONDS` – maximum real seconds before forcing a
+     minute advance even if the simulation isn't waiting (default: twice
+     `MATCH_MINUTE_REAL_SECONDS`).
 
 4. **Running the project**
    ```bash

--- a/realfootballsim/settings.py
+++ b/realfootballsim/settings.py
@@ -13,6 +13,13 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Can be overridden via the MATCH_MINUTE_REAL_SECONDS environment variable.
 MATCH_MINUTE_REAL_SECONDS = int(os.environ.get('MATCH_MINUTE_REAL_SECONDS', 20))
 
+# If a match minute has not advanced after this many real seconds, force the
+# next minute even if waiting_for_next_minute is False. Defaults to twice the
+# normal minute duration.
+MATCH_MINUTE_FORCE_ADVANCE_SECONDS = int(
+    os.environ.get('MATCH_MINUTE_FORCE_ADVANCE_SECONDS', MATCH_MINUTE_REAL_SECONDS * 2)
+)
+
 # Player Personality & Narrative AI Engine
 USE_PERSONALITY_ENGINE = os.environ.get('USE_PERSONALITY_ENGINE', 'True').lower() == 'true'
 


### PR DESCRIPTION
## Summary
- force minute advancement after a real time threshold
- log when `advance_match_minutes` runs
- document `MATCH_MINUTE_FORCE_ADVANCE_SECONDS`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'factory')*

------
https://chatgpt.com/codex/tasks/task_e_6886fb94d9c4832e8ff72e4cf4c6b985